### PR TITLE
update to work with rails 4 router (match deprecated)

### DIFF
--- a/lib/appcache-manifest.rb
+++ b/lib/appcache-manifest.rb
@@ -17,7 +17,7 @@ module Appcache
 
     def set_route
       Rails.application.routes.draw do
-        match @@config.manifest_url => Proc.new {
+        get @@config.manifest_url => Proc.new {
             
             body = []
             body << "" << "NETWORK:"

--- a/lib/appcache-manifest/version.rb
+++ b/lib/appcache-manifest/version.rb
@@ -1,5 +1,5 @@
 module Appcache
   class Manifest
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end


### PR DESCRIPTION
this gem throws an error when used with rails 4.x  I changed it to use get instead of match when defining the route.  that fixed it.
